### PR TITLE
Add Development Origins to CORS Trusted Origins by Default

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -47,6 +47,10 @@ type config struct {
 		redirectURI        string
 	}
 	frontendURL string
+
+	cors struct {
+		trustedOrigins []string
+	}
 }
 
 type application struct {
@@ -99,6 +103,15 @@ func main() {
 	flag.StringVar(&cfg.oauth.googleClientID, "oauth-google-client-id", os.Getenv("GOOGLE_CLIENT_ID"), "Google OAuth Client ID")
 	flag.StringVar(&cfg.oauth.googleClientSecret, "oauth-google-client-secret", os.Getenv("GOOGLE_CLIENT_SECRET"), "Google OAuth Client Secret")
 	flag.StringVar(&cfg.oauth.redirectURI, "oauth-redirect-url", os.Getenv("GOOGLE_REDIRECT_URI"), "OAuth Redirect URL")
+
+	flag.Func("cors-trusted-origins", "Trusted CORS origins (space separated)", func(val string) error {
+		cfg.cors.trustedOrigins = strings.Fields(val)
+		return nil
+	})
+
+	cfg.cors.trustedOrigins = append(cfg.cors.trustedOrigins, "http://localhost:5173", "http://localhost:3000")
+	
+	flag.Parse()
 
 	logger := jsonlog.New(os.Stdout, jsonlog.LevelInfo)
 	if logger == nil {

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -43,6 +43,6 @@ func (app *application) routes() http.Handler {
 	//router.HandlerFunc(http.MethodGet, "/v1/profiles/:username", app.requirePermission("ideas:read", app.getProfileByUsernameHandler))
 
 	router.HandlerFunc(http.MethodGet, "/v1/profiles/id/:userId",  app.getProfileWithIdeasByUserIDHandler)
-	return app.recoverPanic(app.rateLimit(app.authenticate(router)))
+	return app.recoverPanic(app.enableCORS(app.rateLimit(app.authenticate(router))))
 
 }

--- a/cmd/api/user_profiles.go
+++ b/cmd/api/user_profiles.go
@@ -444,7 +444,7 @@ func (app *application) getProfileWithIdeasByUserIDHandler(w http.ResponseWriter
 
 	userID, err := uuid.Parse(userIdParam)
 	if err != nil {
-        app.badRequestResponse(w, r, fmt.Errorf("invalid user ID: %s", err.Error()))
+		app.badRequestResponse(w, r, fmt.Errorf("invalid user ID: %s", err.Error()))
 		return
 	}
 
@@ -481,16 +481,16 @@ func (app *application) getProfileWithIdeasByUserIDHandler(w http.ResponseWriter
 	}
 
 	response := map[string]interface{}{
-		"profile": profile,
-		"ideas": ideas,
+		"profile":     profile,
+		"ideas":       ideas,
 		"ideas_count": totalCount,
-		"limit": limit,
-		"offset": offset,
-	}	
+		"limit":       limit,
+		"offset":      offset,
+	}
 
 	if profile.Avatar != "" && profile.Avatar != "no key" {
-        response["avatarURL"] = fmt.Sprintf("/v1/avatars/%s", profile.Avatar)
-    }
+		response["avatarURL"] = fmt.Sprintf("/v1/avatars/%s", profile.Avatar)
+	}
 
 	err = app.writeJSON(w, http.StatusOK, envelope{"response": response}, nil)
 	if err != nil {


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->

This PR adds localhost development origins to the default CORS trusted origins list to simplify local development.


## Changes Made
Added http://localhost:5173 and http://localhost:3000 to the default CORS trusted origins list
Fixed the flag parsing order to ensure command-line flags take precedence when specified
Maintained compatibility with existing CORS origin configuration